### PR TITLE
Implement `drawSDToFile` for "native" rendering

### DIFF
--- a/app/sampling.hs
+++ b/app/sampling.hs
@@ -1,18 +1,16 @@
-import Diagrams.Prelude
-import Diagrams.Backend.SVG
-import Modelling.StateDiagram.Layout (drawDiagram)
-
 import Modelling.StateDiagram.Generate
 import Modelling.StateDiagram.Checkers (checkDrawability)
 
 import Test.QuickCheck
 import Control.Monad
 import Data.Maybe
+import Data.Functor (($>))
 
 import Text.Pretty.Simple (pPrint)
 
 import Modelling.StateDiagram.Datatype.ClassInstances ()
 import Modelling.StateDiagram.Style (Styling (Unstyled))
+import Modelling.StateDiagram.Render (drawSDToFile)
 
 main :: IO ()
 main = do
@@ -24,4 +22,4 @@ main = do
         putStrLn $ "\nDiscarded " ++ show n ++ " attempts, then got " ++ file ++ ":"
         pPrint sd
         when (isNothing $ checkDrawability sd)
-          $ renderSVG file (mkWidth 250) (drawDiagram Unstyled sd)
+          (drawSDToFile file (Just 250, Nothing) Unstyled sd $> ())

--- a/package.yaml
+++ b/package.yaml
@@ -56,6 +56,7 @@ library:
     - Modelling.StateDiagram.PlantUMLDiagrams
     - Modelling.StateDiagram.Style
     - Modelling.StateDiagram.EnumArrows
+    - Modelling.StateDiagram.Render
   ghc-options:
     - -Wall
     - -Werror

--- a/sd-generate.cabal
+++ b/sd-generate.cabal
@@ -25,6 +25,7 @@ library
       Modelling.StateDiagram.PlantUMLDiagrams
       Modelling.StateDiagram.Style
       Modelling.StateDiagram.EnumArrows
+      Modelling.StateDiagram.Render
   other-modules:
       Modelling.StateDiagram.Arrows
       Modelling.StateDiagram.Checkers.Crossings

--- a/src/Modelling/StateDiagram/EnumArrows.hs
+++ b/src/Modelling/StateDiagram/EnumArrows.hs
@@ -54,7 +54,7 @@ import Modelling.StateDiagram.Config(SDConfig(..)
                                     ,ChartLimits(..)
                                     ,checkSDConfig)
 import Modelling.StateDiagram.Alloy()
-import Modelling.StateDiagram.PlantUMLDiagrams
+import qualified Modelling.StateDiagram.PlantUMLDiagrams as PlantUML
   (drawSDToFile
   ,checkDrawabilityPlantUML)
 import System.FilePath(combine)
@@ -85,10 +85,8 @@ import Data.Either (rights)
 import Control.Monad.Loops (iterateUntil)
 import Modelling.StateDiagram.Checkers (checkDrawability)
 import Data.Maybe (isNothing, fromMaybe, fromJust)
-import Modelling.StateDiagram.Layout (drawDiagram)
 import Modelling.StateDiagram.Style (Styling(Unstyled))
-import Diagrams.Backend.SVG (renderSVG)
-import Diagrams (dims, V2 (V2))
+import qualified Modelling.StateDiagram.Render as NativeRenderer (drawSDToFile)
 import System.Random.Shuffle (shuffleM)
 
 import Data.Time.Clock.POSIX(getPOSIXTime)
@@ -309,13 +307,13 @@ enumArrowsTask path task
       english "Consider the following state chart."
     case chartRenderer task of
        PlantUML
-         -> image $=<< liftIO $ drawSDToFile (combine path "plain") (hierarchicalSD task)
+         -> image $=<< liftIO $ PlantUML.drawSDToFile (combine path "plain") (hierarchicalSD task)
        Diagrams
-         -> image $=<< do liftIO (renderSVG
+         -> image $=<< liftIO (NativeRenderer.drawSDToFile
                                  (combine path "plainDiagram.svg")
-                                 (dims (V2 800 600))
-                                 (drawDiagram Unstyled (hierarchicalSD task)))
-                          return (combine path "plainDiagram.svg")
+                                 (Just 800, Just 600)
+                                 Unstyled
+                                 (hierarchicalSD task))
     paragraph $ translate $ do
       english "Which was flattened, but has all transition triggers disguised through placeholder elements."
     let flatAndEnumeratedSD' -- renaming policy is just a view on data
@@ -327,16 +325,15 @@ enumArrowsTask path task
     case chartRenderer task of
        PlantUML
          -> image $=<< liftIO $
-                        drawSDToFile
+                        PlantUML.drawSDToFile
                         (combine path "flattened")
                         flatAndEnumeratedSD'
        Diagrams
-         -> image $=<< do liftIO (renderSVG
+         -> image $=<< liftIO (NativeRenderer.drawSDToFile
                                  (combine path "flattenedDiagram.svg")
-                                 (dims (V2 800 600))
-                                 (drawDiagram Unstyled
-                                  flatAndEnumeratedSD'))
-                          return (combine path "flattenedDiagram.svg")
+                                 (Just 800, Just 600)
+                                 Unstyled
+                                 flatAndEnumeratedSD')
     paragraph $ translate $ do
       english "Please supply a list of tuples, where the first element is the visible placeholder of a transition as string\n\
                \ and the second element is the transition trigger as string, that is supposed to be at that place."
@@ -432,8 +429,8 @@ canBothBeDrawnVia renderPath hierarchicalSD renaming flatAndEnumeratedSD =
           JustTheInnermostName
             -> rename last flatAndEnumeratedSD
     workingPlantUML =
-      isNothing (checkDrawabilityPlantUML hierarchicalSD) &&
-      isNothing (checkDrawabilityPlantUML flatAndEnumeratedSD')
+      isNothing (PlantUML.checkDrawabilityPlantUML hierarchicalSD) &&
+      isNothing (PlantUML.checkDrawabilityPlantUML flatAndEnumeratedSD')
     workingDiagrams =
       isNothing (checkDrawability hierarchicalSD) &&
       isNothing (checkDrawability flatAndEnumeratedSD')

--- a/src/Modelling/StateDiagram/EnumArrows.hs
+++ b/src/Modelling/StateDiagram/EnumArrows.hs
@@ -307,7 +307,7 @@ enumArrowsTask path task
       english "Consider the following state chart."
     case chartRenderer task of
        PlantUML
-         -> image $=<< liftIO $ PlantUML.drawSDToFile (combine path "plain/Diagram.svg") (hierarchicalSD task)
+         -> image $=<< liftIO $ PlantUML.drawSDToFile (combine path "plainDiagram.svg") (hierarchicalSD task)
        Diagrams
          -> image $=<< liftIO (NativeRenderer.drawSDToFile
                                  (combine path "plainDiagram.svg")
@@ -326,7 +326,7 @@ enumArrowsTask path task
        PlantUML
          -> image $=<< liftIO $
                         PlantUML.drawSDToFile
-                        (combine path "flattened/Diagram.svg")
+                        (combine path "flattenedDiagram.svg")
                         flatAndEnumeratedSD'
        Diagrams
          -> image $=<< liftIO (NativeRenderer.drawSDToFile

--- a/src/Modelling/StateDiagram/EnumArrows.hs
+++ b/src/Modelling/StateDiagram/EnumArrows.hs
@@ -307,7 +307,7 @@ enumArrowsTask path task
       english "Consider the following state chart."
     case chartRenderer task of
        PlantUML
-         -> image $=<< liftIO $ PlantUML.drawSDToFile (combine path "plain") (hierarchicalSD task)
+         -> image $=<< liftIO $ PlantUML.drawSDToFile (combine path "plain/Diagram.svg") (hierarchicalSD task)
        Diagrams
          -> image $=<< liftIO (NativeRenderer.drawSDToFile
                                  (combine path "plainDiagram.svg")
@@ -326,7 +326,7 @@ enumArrowsTask path task
        PlantUML
          -> image $=<< liftIO $
                         PlantUML.drawSDToFile
-                        (combine path "flattened")
+                        (combine path "flattened/Diagram.svg")
                         flatAndEnumeratedSD'
        Diagrams
          -> image $=<< liftIO (NativeRenderer.drawSDToFile

--- a/src/Modelling/StateDiagram/PlantUMLDiagrams.hs
+++ b/src/Modelling/StateDiagram/PlantUMLDiagrams.hs
@@ -177,13 +177,13 @@ getAllHistory (x:xs) context =
   ++ getAllHistory xs context
 
 drawSDToFile :: FilePath -> UMLStateDiagram String Int -> IO FilePath
-drawSDToFile path chart
+drawSDToFile file chart
   = do
     rendered <- renderAll Unstyled chart
     let plantUML = pack rendered
     picture <- drawPlantUMLDiagram SVG plantUML
-    writeFile (path ++ "Diagram.svg") (unpack picture)
-    return (path ++ "Diagram.svg")
+    writeFile file (unpack picture)
+    return file
 
 -- TODO: i'm a stub, please update me once the reasons
 --       why PlantUML crashes on certain chart instances are known better

--- a/src/Modelling/StateDiagram/Render.hs
+++ b/src/Modelling/StateDiagram/Render.hs
@@ -1,0 +1,18 @@
+module Modelling.StateDiagram.Render where
+
+import Diagrams (V2 (V2), absolute, dims, mkHeight, mkWidth)
+import Diagrams.Backend.SVG (renderSVG)
+import Modelling.StateDiagram.Datatype (UMLStateDiagram)
+import Modelling.StateDiagram.Layout (drawDiagram)
+import Modelling.StateDiagram.Style (Styling)
+
+drawSDToFile :: FilePath -> (Maybe Double, Maybe Double) -> Styling -> UMLStateDiagram String Int -> IO FilePath
+drawSDToFile file mSize style sd = do
+  renderSVG file size $ drawDiagram style sd
+  pure file
+  where
+    size = case mSize of
+      (Nothing, Nothing) -> absolute
+      (Just width, Nothing) -> mkWidth width
+      (Nothing, Just height) -> mkHeight height
+      (Just width, Just height) -> dims (V2 width height)


### PR DESCRIPTION
Also aligns the signature of `drawSDToFile` from PlantUMLDiagrams with other rendering functions / `image` from `output-blocks`